### PR TITLE
PoW retargeting change for BTG hard fork permine proid.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -79,6 +79,8 @@ public:
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        consensus.BTGHeight = 487427; // Around 10/1/2017 12:00 UTC
+        consensus.BTGPremineWindow = 16000;
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -183,6 +185,8 @@ public:
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
         consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+        consensus.BTGHeight = 100000000; // Not activated yet.
+        consensus.BTGPremineWindow = 16000;
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -271,6 +275,8 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
+        consensus.BTGHeight = 100000000; // Not activated yet.
+        consensus.BTGPremineWindow = 16000;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -46,6 +46,10 @@ struct Params {
     int BIP65Height;
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
+    /** Block height at which Bitcoin GPU hard fork becomes active */
+    int BTGHeight;
+    /** Premining blocks for Bitcoin GPU hard fork **/
+    int BTGPremineWindow;
     /**
      * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -15,9 +15,15 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     assert(pindexLast != nullptr);
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
-    // Only change once per difficulty adjustment interval
-    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
+    int nHeightNext = pindexLast->nHeight + 1;
+    if (nHeightNext >= params.BTGHeight  && nHeightNext < params.BTGHeight + params.BTGPremineWindow)
     {
+        // Lowest difficulty for Bitcoin GPU premining period.
+        return nProofOfWorkLimit;
+    }
+    else if (nHeightNext % params.DifficultyAdjustmentInterval() != 0)
+    {
+        // Difficulty adjustment interval is not finished. Keep the last value.
         if (params.fPowAllowMinDifficultyBlocks)
         {
             // Special difficulty rule for testnet:


### PR DESCRIPTION
- Fork from block #487427 (Oct. 1st, 12:00 UTC).
- Premine 16000 blocks.
- Minimal difficulty for the premining peroid.