### PR TITLE
Link to our own website for security issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@ This issue tracker is only for technical issues related to bitcoin-core.
 
 General bitcoin questions and/or support requests and are best directed to the [Bitcoin StackExchange](https://bitcoin.stackexchange.com).
 
-For reporting security issues, please read instructions at [https://bitcoincore.org/en/contact/](https://bitcoincore.org/en/contact/).
+For reporting security issues, please see the official [Bitcoin Gold website](https://btcgpu.org/).
 
 ### Describe the issue
 


### PR DESCRIPTION
Until we have a dedicated URL

Better than linking to Bitcoin core, we submit bugs to them, our users submit bugs to us. Zcash has a dedicated `doc/security.md` which Hush inherited and that I maintain for Hush.