### PR TITLE
Implement Strong Replay Protection

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -188,7 +188,7 @@ static CAmount ExtractAndValidateValue(const std::string& strValue)
 static void MutateTxVersion(CMutableTransaction& tx, const std::string& cmdVal)
 {
     int64_t newVersion = atoi64(cmdVal);
-    if (newVersion < 1 || newVersion > CTransaction::MAX_STANDARD_VERSION)
+    if (newVersion > 0 || newVersion < CTransaction::MIN_STANDARD_VERSION)
         throw std::runtime_error("Invalid TX version requested");
 
     tx.nVersion = (int) newVersion;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -98,8 +98,8 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType, const bool w
 
 bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnessEnabled)
 {
-    if (tx.nVersion > CTransaction::MAX_STANDARD_VERSION || tx.nVersion < 1) {
-        reason = "version";
+    if (tx.nVersion > 0 || tx.nVersion < CTransaction::MIN_STANDARD_VERSION) {
+        reason = "Bitcoin Gold tx versions are negative for replay protection against Bitcoin";
         return false;
     }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -265,13 +265,13 @@ class CTransaction
 {
 public:
     // Default transaction version.
-    static const int32_t CURRENT_VERSION=2;
+    static const int32_t CURRENT_VERSION=-1;
 
     // Changing the default transaction version requires a two step process: first
-    // adapting relay policy by bumping MAX_STANDARD_VERSION, and then later date
+    // adapting relay policy by bumping MIN_STANDARD_VERSION, and then later date
     // bumping the default CURRENT_VERSION at which point both CURRENT_VERSION and
-    // MAX_STANDARD_VERSION will be equal.
-    static const int32_t MAX_STANDARD_VERSION=2;
+    // MIN_STANDARD_VERSION will be equal.
+    static const int32_t MIN_STANDARD_VERSION=-1;
 
     // The local variables are made const to prevent unintended modification
     // without updating the cached hash value. However, CTransaction is not

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -45,7 +45,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
     spends.resize(2);
     for (int i = 0; i < 2; i++)
     {
-        spends[i].nVersion = 1;
+        spends[i].nVersion = -1;
         spends[i].vin.resize(1);
         spends[i].vin[0].prevout.hash = coinbaseTxns[0].GetHash();
         spends[i].vin[0].prevout.n = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2831,11 +2831,15 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-multiple", false, "more than one coinbase");
 
     // Check transactions
-    for (const auto& tx : block.vtx)
+    for (const auto& tx : block.vtx) {
+        if (block.nHeight >= (uint32_t)consensusParams.BTGHeight && tx->nVersion > 0) {
+            return state.Invalid(false, REJECT_INVALID, "Replay Protection of Bitcoin Gold against Bitcoin",
+                strprintf("Positive transaction version number detected. Invalid for Bitcoin Gold replay protection: %d", tx->nVersion));
+        }
         if (!CheckTransaction(*tx, state, false))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
-
+    }
     unsigned int nSigOps = 0;
     for (const auto& tx : block.vtx)
     {


### PR DESCRIPTION
This method of replay protection used is described by
Dr. Greg Maxwell here:
https://github.com/Bitcoin-ABC/bitcoin-abc/issues/28#issue-245232082

In short, the basic idea is that all Bitcoin Gold transactions
will use a negative version number.  Bitcoin already enforces that
all transaction version numbers must be positve.

This method is simple, robust, and has mandatory enforcement.