### PR TITLE
[WIP] Change mainnet address version.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -364,8 +364,6 @@ libbitcoin_cli_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_cli_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_cli_a_SOURCES = \
   rpc/client.cpp \
-  $(libbitcoin_common_a_SOURCES) \
-  $(libbitcoin_consensus_a_SOURCES) \
   $(BITCOIN_CORE_H)
 
 nodist_libbitcoin_util_a_SOURCES = $(srcdir)/obj/build.h
@@ -409,6 +407,9 @@ endif
 
 bgold_cli_LDADD = \
   $(LIBBITCOIN_CLI) \
+  $(LIBBITCOIN_COMMON) \
+  $(LIBBITCOIN_CONSENSUS) \
+  $(LIBSECP256K1) \
   $(LIBUNIVALUE) \
   $(LIBBITCOIN_UTIL) \
   $(LIBBITCOIN_CRYPTO)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -364,6 +364,8 @@ libbitcoin_cli_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_cli_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_cli_a_SOURCES = \
   rpc/client.cpp \
+  $(libbitcoin_common_a_SOURCES) \
+  $(libbitcoin_consensus_a_SOURCES) \
   $(BITCOIN_CORE_H)
 
 nodist_libbitcoin_util_a_SOURCES = $(srcdir)/obj/build.h

--- a/src/base58.h
+++ b/src/base58.h
@@ -106,16 +106,22 @@ public:
     bool Set(const CKeyID &id);
     bool Set(const CScriptID &id);
     bool Set(const CTxDestination &dest);
+    bool Set(const CKeyID &id, const CChainParams &params);
+    bool Set(const CScriptID &id, const CChainParams &params);
+    bool Set(const CTxDestination &dest, const CChainParams &params);
     bool IsValid() const;
     bool IsValid(const CChainParams &params) const;
 
     CBitcoinAddress() {}
     CBitcoinAddress(const CTxDestination &dest) { Set(dest); }
+    CBitcoinAddress(const CTxDestination &dest, const CChainParams &params) { Set(dest, params); }
     CBitcoinAddress(const std::string& strAddress) { SetString(strAddress); }
     CBitcoinAddress(const char* pszAddress) { SetString(pszAddress); }
 
     CTxDestination Get() const;
+    CTxDestination Get(const CChainParams &params) const;
     bool GetKeyID(CKeyID &keyID) const;
+    bool GetKeyID(CKeyID &keyID, const CChainParams &params) const;
     bool IsScript() const;
 };
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -49,6 +49,7 @@ std::string HelpMessageCli()
     strUsage += HelpMessageOpt("-rpcclienttimeout=<n>", strprintf(_("Timeout in seconds during HTTP requests, or 0 for no timeout. (default: %d)"), DEFAULT_HTTP_CLIENT_TIMEOUT));
     strUsage += HelpMessageOpt("-stdin", _("Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases)"));
     strUsage += HelpMessageOpt("-rpcwallet=<walletname>", _("Send RPC for non-default wallet on RPC server (argument is wallet filename in bitcoind directory, required if bitcoind/-Qt runs with multiple wallets)"));
+    strUsage += HelpMessageOpt("-convertaddress=<bticoin_address>", _("Convert a Bitcoin address into Bitcoin Gold address format."));
 
     return strUsage;
 }
@@ -105,7 +106,8 @@ static int AppInitRPC(int argc, char* argv[])
                   "  bitcoin-cli [options] <command> [params]  " + strprintf(_("Send command to %s"), _(PACKAGE_NAME)) + "\n" +
                   "  bitcoin-cli [options] -named <command> [name=value] ... " + strprintf(_("Send command to %s (with named arguments)"), _(PACKAGE_NAME)) + "\n" +
                   "  bitcoin-cli [options] help                " + _("List commands") + "\n" +
-                  "  bitcoin-cli [options] help <command>      " + _("Get help for a command") + "\n";
+                  "  bitcoin-cli [options] help <command>      " + _("Get help for a command") + "\n"
+                  "  bitcoin-cli [options] -convertaddress=address " + _("Convert Bitcoin address to Bitcoin Gold address")  + "\n";
 
             strUsage += "\n" + HelpMessageCli();
         }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -157,8 +157,8 @@ public:
         vSeeds.emplace_back("seed.bitcoin.jonasschnelli.ch", true); // Jonas Schnelli, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("seed.btc.petertodd.org", true); // Peter Todd, only supports x1, x5, x9, and xd
 
-        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,0);
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,38);  // prefix: G
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,90);  // prefix: d
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,128);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -378,11 +378,28 @@ public:
     }
 };
 
-static std::unique_ptr<CChainParams> globalChainParams;
+class BitcoinAddressChainParam : public CMainParams
+{
+public:
+    BitcoinAddressChainParam()
+    {
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,0);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
+    }
+};
 
-const CChainParams &Params() {
+static std::unique_ptr<CChainParams> globalChainParams;
+static BitcoinAddressChainParam chainParamsForAddressConversion;
+
+const CChainParams &Params()
+{
     assert(globalChainParams);
     return *globalChainParams;
+}
+
+const CChainParams &BitcoinAddressFormatParams()
+{
+    return chainParamsForAddressConversion;
 }
 
 std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -158,7 +158,7 @@ public:
         vSeeds.emplace_back("seed.btc.petertodd.org", true); // Peter Todd, only supports x1, x5, x9, and xd
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,38);  // prefix: G
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,90);  // prefix: d
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,23);  // prefix: A
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,128);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -114,6 +114,12 @@ std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain);
 const CChainParams &Params();
 
 /**
+ * Return the chain parameters with Bitcoin address format. This is used for
+ * address conversion.
+ */
+const CChainParams &BitcoinAddressFormatParams();
+
+/**
  * Sets the params returned by Params() to those for the given BIP70 chain name.
  * @throws std::runtime_error when the chain is not supported.
  */

--- a/src/test/data/base58_keys_invalid.json
+++ b/src/test/data/base58_keys_invalid.json
@@ -148,5 +148,11 @@
     ], 
     [
         "2A1q1YsMZowabbvta7kTy2Fd6qN4r5ZCeG3qLpvZBMzCixMUdkN2Y4dHB1wPsZAeVXUGD83MfRED"
+    ],
+    [
+        "16FoV6CpUT5YPHL8rcY7SQoHvnyXY4yRsD"
+    ],
+    [
+        "3CjLoKt9KYcfjf4MWAbGz8xnpfJvzvMxMi"
     ]
 ]

--- a/src/test/data/base58_keys_valid.json
+++ b/src/test/data/base58_keys_valid.json
@@ -1,6 +1,6 @@
 [
     [
-        "1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i", 
+        "GT7Hz8QWPNmrZ9Z1mEgpYKN7Jdp97eoQjN", 
         "65a16059864a2fdbc7c99a4723a8395bc6f188eb", 
         {
             "addrType": "pubkey", 
@@ -9,7 +9,7 @@
         }
     ], 
     [
-        "3CMNFxN1oHBc4R1EpboAL5yzHGgE611Xou", 
+        "ASSDyujCaXXNnDWoG9nu4Lt9cMKCrt2jX2",
         "74f209f6ea907e2ea48f74fae05782ae8a665257", 
         {
             "addrType": "script", 
@@ -72,7 +72,7 @@
         }
     ], 
     [
-        "1Ax4gZtb7gAit2TivwejZHYtNNLT18PUXJ", 
+        "GTnz6hDY6Xn1xVm1rtJqz3tnHY8J3nFqAJ", 
         "6d23156cbbdcc82a5a47eee4c2c7c583c18b6bf4", 
         {
             "addrType": "pubkey", 
@@ -81,7 +81,7 @@
         }
     ], 
     [
-        "3QjYXhTkvuj8qPaXHTTWb5wjXhdsLAAWVy", 
+        "AepQFepwiA4uZC65j1TFKLqtrnGr5jsYJu",
         "fcc5460dd6e2487c7d75b1963625da0e8f4c5975", 
         {
             "addrType": "script", 
@@ -144,7 +144,7 @@
         }
     ], 
     [
-        "1C5bSj1iEGUgSTbziymG7Cn18ENQuT36vv", 
+        "GUvWrrLfD85yWvuHevRNXy7u3QAG2FZzwe", 
         "7987ccaa53d02c8873487ef919677cd3db7a6912", 
         {
             "addrType": "pubkey", 
@@ -153,7 +153,7 @@
         }
     ], 
     [
-        "3AnNxabYGoTxYiTEZwFEnerUoeFXK2Zoks", 
+        "AQsEgXxj43ojGWxo1VEyWuke8itW6qYFAx",
         "63bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb", 
         {
             "addrType": "script", 
@@ -216,7 +216,7 @@
         }
     ], 
     [
-        "1Gqk4Tv79P91Cc1STQtU3s1W6277M2CVWu", 
+        "GZgfUbF48EkJH5JjPMYaUdMQ1BtxM3NAcb", 
         "adc1cc2081a27206fae25792f28bbc55b831549d", 
         {
             "addrType": "pubkey", 
@@ -225,7 +225,7 @@
         }
     ], 
     [
-        "33vt8ViH5jsr115AGkW6cEmEz9MpvJSwDk", 
+        "AJ1jrT5TrzDcioaiiJVqLVfQKDzonkUT2V",
         "188f91a931947eddd7432d6e614387e32b244709", 
         {
             "addrType": "script", 
@@ -288,7 +288,7 @@
         }
     ], 
     [
-        "1JwMWBVLtiqtscbaRHai4pqHokhFCbtoB4", 
+        "GbnGvJpHsaTBx5tsMEEpVbBBivV6Ebkyr8", 
         "c4c1b72491ede1eedaca00618407ee0b772cad0d", 
         {
             "addrType": "pubkey", 
@@ -297,7 +297,7 @@
         }
     ], 
     [
-        "3QCzvfL4ZRvmJFiWWBVwxfdaNBT8EtxB5y", 
+        "AeHrechFLgGY24E4wjVggvXjhG672rsLn1",
         "f6fe69bcb548a829cce4c57bf6fff8af3a5981f9", 
         {
             "addrType": "script", 
@@ -360,7 +360,7 @@
         }
     ], 
     [
-        "19dcawoKcZdQz365WpXWMhX6QCUpR9SY4r", 
+        "GSUY158GbREi4WPNSmBcnTrzKNGfR3eovz", 
         "5eadaf9bb7121f0f192561a5a62f5e5f54210292", 
         {
             "addrType": "pubkey", 
@@ -369,7 +369,7 @@
         }
     ], 
     [
-        "37Sp6Rv3y4kVd1nQ1JV5pfqXccHNyZm1x3", 
+        "AMXfpPHEkK6GLpHxSrUpYvjgwgvMrTRQxw",
         "3f210e7277c899c3a155cc1c90f4106cbddeec6e", 
         {
             "addrType": "script", 
@@ -432,7 +432,7 @@
         }
     ], 
     [
-        "13p1ijLwsnrcuyqcTvJXkq2ASdXqcnEBLE", 
+        "GLew8rftreTuzT8uPrxeBbN4MoKgfFx3BA", 
         "1ed467017f043e91ed4c44b4e8dd674db211c4e6", 
         {
             "addrType": "pubkey", 
@@ -441,7 +441,7 @@
         }
     ], 
     [
-        "3ALJH9Y951VCGcVZYAdpA3KchoP9McEj1G", 
+        "AQRA16uKrFpxzR17yidYtJDn2t287dc1XY", 
         "5ece0cadddc415b1980f001785947120acdb36fc", 
         {
             "addrType": "script", 

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -20,13 +20,13 @@ static const std::string strSecret1     ("5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZj
 static const std::string strSecret2     ("5KC4ejrDjv152FGwP386VD1i2NYc5KkfSMyv1nGy1VGDxGHqVY3");
 static const std::string strSecret1C    ("Kwr371tjA9u2rFSMZjTNun2PXXP3WPZu2afRHTcta6KxEUdm1vEw");
 static const std::string strSecret2C    ("L3Hq7a8FEQwJkW1M2GNKDW28546Vp5miewcCzSqUD9kCAXrJdS3g");
-static const CBitcoinAddress addr1 ("1QFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ");
-static const CBitcoinAddress addr2 ("1F5y5E5FMc5YzdJtB9hLaUe43GDxEKXENJ");
-static const CBitcoinAddress addr1C("1NoJrossxPBKfCHuJXT4HadJrXRE9Fxiqs");
-static const CBitcoinAddress addr2C("1CRj2HyM1CXWzHAXLQtiGLyggNT9WQqsDs");
+static const CBitcoinAddress addr1 ("Gh6mFUoA3wAn7rbXEWYgjyDJgu8J72tcLH");
+static const CBitcoinAddress addr2 ("GXvtVMQCLTgr56cB76MT1EywxS1oCDN6em");
+static const CBitcoinAddress addr1C("GfeEGwCpwEncjfbCEU7AiLyCmhD5A3KWsz");
+static const CBitcoinAddress addr2C("GVGeSRJHz48p4kTpGMYph7KabYEzYyPDXr");
 
 
-static const std::string strAddressBad("1HV9Lc3sNHZxwj4Zk6fB38tEmBryq2cBiF");
+static const std::string strAddressBad("GaL4kjNpM9BG2CMrg3KHTuE8gMepr8AE7o");
 
 
 BOOST_FIXTURE_TEST_SUITE(key_tests, BasicTestingSetup)

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
       "\"vout\":1,\"scriptPubKey\":\"a914b10c9df5f7edf436c697f02f1efdba4cf399615187\","
       "\"redeemScript\":\"512103debedc17b3df2badbcdd86d5feb4562b86fe182e5998abd8bcd4f122c6155b1b21027e940bb73ab8732bfdf7f9216ecefca5b94d6df834e77e108f68e66f126044c052ae\"}]";
     r = CallRPC(std::string("createrawtransaction ")+prevout+" "+
-      "{\"3HqAe9LtNBjnsfM4CyYaWTnvCaUYT7v4oZ\":11}");
+      "{\"AXv2N6i59S5ZbTrceXYKEih5Xf7XGqxpc6\":11}");
     std::string notsigned = r.get_str();
     std::string privkey1 = "\"KzsXybp9jX64P5ekX1KUxRQ79Jht9uzW7LorgwE65i5rWACL6LQe\"";
     std::string privkey2 = "\"Kyhdf5LuKTRx4ge69ybABsiUAWjVRK4XGxAKk2FQLp2HjGMy87Z4\"";

--- a/test/util/data/bitcoin-util-test.json
+++ b/test/util/data/bitcoin-util-test.json
@@ -87,7 +87,7 @@
   { "exec": "./bitcoin-tx",
     "args":
     ["-create",
-     "outaddr=1:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o:garbage"],
+     "outaddr=1:GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe:garbage"],
     "return_code": 1,
     "error_txt": "error: TX output missing or too many separators",
     "description": "Malformed outaddr argument (too many separators). Expected to fail."
@@ -114,8 +114,8 @@
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
      "in=bf829c6bcf84579331337659d31f89dfd138f7f7785802d5501c92333145ca7c:18",
      "in=22a6f904655d53ae2ff70e701a0bbd90aa3975c0f40bfc6cc996a9049e31cdfc:1",
-     "outaddr=0.18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
-     "outaddr=4:1P8yWvZW8jVihP1bzHeqfE4aoXNX8AVa46"],
+     "outaddr=0.18:GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe",
+     "outaddr=4:Gfytw3tT7b71mrJtvEJx5zQUihANBC5QGE"],
     "output_cmp": "txcreate1.hex",
     "description": "Creates a new transaction with three inputs and two outputs"
   },
@@ -126,8 +126,8 @@
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
      "in=bf829c6bcf84579331337659d31f89dfd138f7f7785802d5501c92333145ca7c:18",
      "in=22a6f904655d53ae2ff70e701a0bbd90aa3975c0f40bfc6cc996a9049e31cdfc:1",
-     "outaddr=0.18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
-     "outaddr=4:1P8yWvZW8jVihP1bzHeqfE4aoXNX8AVa46"],
+     "outaddr=0.18:GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe",
+     "outaddr=4:Gfytw3tT7b71mrJtvEJx5zQUihANBC5QGE"],
     "output_cmp": "txcreate1.json",
     "description": "Creates a new transaction with three inputs and two outputs (output in json)"
   },
@@ -198,7 +198,7 @@
      "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
      "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
      "sign=ALL",
-     "outaddr=0.001:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7"],
+     "outaddr=0.001:GRtJWUDsQvPVsDXDH6ZeCn2mMbdY4gCou6"],
     "output_cmp": "txcreatesignv1.hex",
     "description": "Creates a new v1 transaction with a single input and a single output, and then signs the transaction"
   },
@@ -210,7 +210,7 @@
      "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
      "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
      "sign=ALL",
-     "outaddr=0.001:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7"],
+     "outaddr=0.001:GRtJWUDsQvPVsDXDH6ZeCn2mMbdY4gCou6"],
     "output_cmp": "txcreatesignv1.json",
     "description": "Creates a new v1 transaction with a single input and a single output, and then signs the transaction (output in json)"
   },
@@ -221,7 +221,7 @@
       "set=privatekeys:[\"5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
       "sign=ALL",
-      "outaddr=0.001:193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7"],
+      "outaddr=0.001:GRtJWUDsQvPVsDXDH6ZeCn2mMbdY4gCou6"],
     "output_cmp": "txcreatesignv2.hex",
     "description": "Creates a new transaction with a single input and a single output, and then signs the transaction"
   },
@@ -283,7 +283,7 @@
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-     "outaddr=0.18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
+     "outaddr=0.18:GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe",
      "outdata=4:54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"],
     "output_cmp": "txcreatedata1.hex",
     "description": "Creates a new transaction with one input, one address output and one data output"
@@ -293,7 +293,7 @@
     ["-json",
      "-create", "nversion=1",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-     "outaddr=0.18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
+     "outaddr=0.18:GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe",
      "outdata=4:54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"],
     "output_cmp": "txcreatedata1.json",
     "description": "Creates a new v1 transaction with one input, one address output and one data output (output in json)"
@@ -302,7 +302,7 @@
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-     "outaddr=0.18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
+     "outaddr=0.18:GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe",
      "outdata=54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"],
     "output_cmp": "txcreatedata2.hex",
     "description": "Creates a new transaction with one input, one address output and one data (zero value) output"
@@ -312,7 +312,7 @@
     ["-json",
      "-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
-     "outaddr=0.18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o",
+     "outaddr=0.18:GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe",
      "outdata=54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"],
     "output_cmp": "txcreatedata2.json",
     "description": "Creates a new transaction with one input, one address output and one data (zero value) output (output in json)"
@@ -321,7 +321,7 @@
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0:4294967293",
-     "outaddr=0.18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"],
+     "outaddr=0.18:GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe"],
     "output_cmp": "txcreatedata_seq0.hex",
     "description": "Creates a new transaction with one input with sequence number and one address output"
   },
@@ -330,7 +330,7 @@
     ["-json",
      "-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0:4294967293",
-     "outaddr=0.18:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"],
+     "outaddr=0.18:GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe"],
     "output_cmp": "txcreatedata_seq0.json",
     "description": "Creates a new transaction with one input with sequence number and one address output (output in json)"
   },

--- a/test/util/data/tt-delin1-out.json
+++ b/test/util/data/tt-delin1-out.json
@@ -197,7 +197,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1E7SGgAZFCHDnVZLuRViX3gUmxpMfdvd2o"
+                    "GWxMgoVWE3tWrxrdqN9pwp2Nh8cCej5G54"
                 ]
             }
         }, 
@@ -210,7 +210,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1AtWkdmfmYkErU16d3KYykJUbEp9MAj9Sb"
+                    "GTjSAm6ckQMXvwJPYyyfQWeNWQbzM2xVWw"
                 ]
             }
         }

--- a/test/util/data/tt-delout1-out.json
+++ b/test/util/data/tt-delout1-out.json
@@ -206,7 +206,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1E7SGgAZFCHDnVZLuRViX3gUmxpMfdvd2o"
+                    "GWxMgoVWE3tWrxrdqN9pwp2Nh8cCej5G54"
                 ]
             }
         }

--- a/test/util/data/tt-locktime317000-out.json
+++ b/test/util/data/tt-locktime317000-out.json
@@ -206,7 +206,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1E7SGgAZFCHDnVZLuRViX3gUmxpMfdvd2o"
+                    "GWxMgoVWE3tWrxrdqN9pwp2Nh8cCej5G54"
                 ]
             }
         }, 
@@ -219,7 +219,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1AtWkdmfmYkErU16d3KYykJUbEp9MAj9Sb"
+                    "GTjSAm6ckQMXvwJPYyyfQWeNWQbzM2xVWw"
                 ]
             }
         }

--- a/test/util/data/txcreate1.json
+++ b/test/util/data/txcreate1.json
@@ -44,7 +44,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+                    "GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe"
                 ]
             }
         }, 
@@ -57,7 +57,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "1P8yWvZW8jVihP1bzHeqfE4aoXNX8AVa46"
+                    "Gfytw3tT7b71mrJtvEJx5zQUihANBC5QGE"
                 ]
             }
         }

--- a/test/util/data/txcreatedata1.json
+++ b/test/util/data/txcreatedata1.json
@@ -26,7 +26,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+                    "GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe"
                 ]
             }
         }, 

--- a/test/util/data/txcreatedata2.json
+++ b/test/util/data/txcreatedata2.json
@@ -26,7 +26,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+                    "GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe"
                 ]
             }
         }, 

--- a/test/util/data/txcreatedata_seq0.json
+++ b/test/util/data/txcreatedata_seq0.json
@@ -26,7 +26,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+                    "GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe"
                 ]
             }
         }

--- a/test/util/data/txcreatedata_seq1.json
+++ b/test/util/data/txcreatedata_seq1.json
@@ -35,7 +35,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "13tuJJDR2RgArmgfv6JScSdreahzgc4T6o"
+                    "GLjpiRYN1HHTwEyxr2xZ3CykZkVqjAT3fe"
                 ]
             }
         }

--- a/test/util/data/txcreatemultisig1.json
+++ b/test/util/data/txcreatemultisig1.json
@@ -17,9 +17,9 @@
                 "reqSigs": 2,
                 "type": "multisig",
                 "addresses": [
-                    "1FoG2386FG2tAJS9acMuiDsKy67aGg9MKz", 
-                    "1FXtz9KU8JNmQDyHdiEm5HDiALuP3zdHvV", 
-                    "14LuavcBbXZYJ6Tsz3cAUQj9SuQoL2xCQX"
+                    "GYeBSAT3E7eBEmjSWZ228zDDtFuRGUN6Dd", 
+                    "GYNpQGeR79z4UhGaZetsW3Zc5WhE7g1uwB", 
+                    "GMBq13w8aPAqNZmAuzGGuB53N5CeM5MHdP"
                 ]
             }
         }

--- a/test/util/data/txcreatemultisig2.json
+++ b/test/util/data/txcreatemultisig2.json
@@ -17,7 +17,7 @@
                 "reqSigs": 1,
                 "type": "scripthash",
                 "addresses": [
-                    "34HNh57oBCRKkxNyjTuWAJkTbuGh6jg2Ms"
+                    "AJNER2UyxSm6UktYB1uEtZecvyufsYGdTG"
                 ]
             }
         }

--- a/test/util/data/txcreatemultisig4.json
+++ b/test/util/data/txcreatemultisig4.json
@@ -17,7 +17,7 @@
                 "reqSigs": 1,
                 "type": "scripthash",
                 "addresses": [
-                    "3BoFUz1StqcNcgUTZE5cC1eFhuYFzj3fGH"
+                    "ARt7CwNdg5x9LUz1zn5LvGYR2zBEovmF7J"
                 ]
             }
         }

--- a/test/util/data/txcreateoutpubkey1.json
+++ b/test/util/data/txcreateoutpubkey1.json
@@ -17,7 +17,7 @@
                 "reqSigs": 1,
                 "type": "pubkey",
                 "addresses": [
-                    "1FoG2386FG2tAJS9acMuiDsKy67aGg9MKz"
+                    "GYeBSAT3E7eBEmjSWZ228zDDtFuRGUN6Dd"
                 ]
             }
         }

--- a/test/util/data/txcreateoutpubkey3.json
+++ b/test/util/data/txcreateoutpubkey3.json
@@ -17,7 +17,7 @@
                 "reqSigs": 1,
                 "type": "scripthash",
                 "addresses": [
-                    "3GnzN8FqgvYGYdhj8NW6UNxxVv3Uj1ApQn"
+                    "AWsr65d2UAt3GSDHZvVqCds7pzgTSyowJQ"
                 ]
             }
         }

--- a/test/util/data/txcreatescript2.json
+++ b/test/util/data/txcreatescript2.json
@@ -17,7 +17,7 @@
                 "reqSigs": 1,
                 "type": "scripthash",
                 "addresses": [
-                    "3C5QarEGh9feKbDJ3QbMf2YNjnMoiPDhNp"
+                    "ASAGJobTUQ1R3PirUxb6PHSY4rznXGCovf"
                 ]
             }
         }

--- a/test/util/data/txcreatescript4.json
+++ b/test/util/data/txcreatescript4.json
@@ -17,7 +17,7 @@
                 "reqSigs": 1,
                 "type": "scripthash",
                 "addresses": [
-                    "3BNQbeFeJJGMAyDxPwWPuqxPMrjsFLjk3f"
+                    "ARTGKbcq5Yc7tmjWqVW8e6rYgwNqyRcZ9F"
                 ]
             }
         }

--- a/test/util/data/txcreatesignv1.json
+++ b/test/util/data/txcreatesignv1.json
@@ -26,7 +26,7 @@
                 "reqSigs": 1,
                 "type": "pubkeyhash",
                 "addresses": [
-                    "193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7"
+                    "GRtJWUDsQvPVsDXDH6ZeCn2mMbdY4gCou6"
                 ]
             }
         }


### PR DESCRIPTION
- Prefix 38 (G) for P2PKH.
- Prefix 23 (A) for P2SH.
- Convert tool: `bgold-cli -testnet=false -convertaddress=<old-address>`

Status:
- [x] Change format version for mainnet.
- [x] All test cases
- [x] Tool to convert addresses from old to new format.