### PR TITLE
Disable LogPrint in target libconsensus_la.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -297,9 +297,9 @@ AC_ARG_WITH([utils],
 
 AC_ARG_WITH([libs],
   [AS_HELP_STRING([--with-libs],
-  [build libraries (default=yes)])],
+  [build libraries (default=no)])],
   [build_bitcoin_libs=$withval],
-  [build_bitcoin_libs=yes])
+  [build_bitcoin_libs=no])
 
 AC_ARG_WITH([daemon],
   [AS_HELP_STRING([--with-daemon],
@@ -1030,7 +1030,7 @@ AC_SUBST(UNIVALUE_LIBS)
 
 BITCOIN_QT_PATH_PROGS([PROTOC], [protoc],$protoc_bin_path)
 
-LIBEQUIHASH_LIBS="-lcrypto -lsodium -lboost_system"
+LIBEQUIHASH_LIBS="-lcrypto -lsodium"
 
 AC_MSG_CHECKING([whether to build bitcoind])
 AM_CONDITIONAL([BUILD_BITCOIND], [test x$build_bitcoind = xyes])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -446,8 +446,8 @@ if GLIBC_BACK_COMPAT
 endif
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
-libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
-libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
+libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1) $(BOOST_LIBS) $(LIBEQUIHASH_LIBS)
+libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL -DNO_UTIL_LOG
 libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 endif

--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -17,7 +17,12 @@
 #endif
 
 #include "crypto/equihash.h"
+
+#ifndef NO_UTIL_LOG
 #include "util.h"
+#else
+#define LogPrint(...)
+#endif
 
 #include <algorithm>
 #include <iostream>


### PR DESCRIPTION
Target libconsensus_la doesn't link to `util.cpp` so it's not feasible to invoke LogPrint. Add this to fix the compiling error.