### PR TITLE
Flag to disable IBD after fork.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -419,6 +419,7 @@ std::string HelpMessage(HelpMessageMode mode)
         " " + _("Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway"));
     strUsage += HelpMessageOpt("-maxuploadtarget=<n>", strprintf(_("Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)"), DEFAULT_MAX_UPLOAD_TARGET));
     strUsage += HelpMessageOpt("-bootstrap", _("Enables Bitcoin Gold bootstrap mode. Allows BTG client to connect to Bitcoin p2p network to download blockahin history."));
+    strUsage += HelpMessageOpt("skiphardforkibd", _("Skip Initial Block Download when reaching hardfork block."));
 
 #ifdef ENABLE_WALLET
     strUsage += CWallet::GetWalletHelpString(showDebug);
@@ -1369,6 +1370,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     fBTGBootstrapping = gArgs.GetBoolArg("-bootstrap", false);
+    fSkipHardforkIBD = gArgs.GetBoolArg("-skiphardforkibd", false);
 
     // ********************************************************* Step 7: load block chain
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -419,7 +419,7 @@ std::string HelpMessage(HelpMessageMode mode)
         " " + _("Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway"));
     strUsage += HelpMessageOpt("-maxuploadtarget=<n>", strprintf(_("Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)"), DEFAULT_MAX_UPLOAD_TARGET));
     strUsage += HelpMessageOpt("-bootstrap", _("Enables Bitcoin Gold bootstrap mode. Allows BTG client to connect to Bitcoin p2p network to download blockahin history."));
-    strUsage += HelpMessageOpt("skiphardforkibd", _("Skip Initial Block Download when reaching hardfork block."));
+    strUsage += HelpMessageOpt("-skiphardforkibd", _("Skip Initial Block Download when reaching hardfork block."));
 
 #ifdef ENABLE_WALLET
     strUsage += CWallet::GetWalletHelpString(showDebug);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -35,6 +35,7 @@ static proxyType nameProxy;
 static CCriticalSection cs_proxyInfos;
 int nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 bool fNameLookup = DEFAULT_NAME_LOOKUP;
+bool fSkipHardforkIBD = false;
 bool fBTGBootstrapping = false;
 
 // Need ample time for negotiation for very slow proxies such as Tor (milliseconds)

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -20,6 +20,7 @@
 extern int nConnectTimeout;
 extern bool fNameLookup;
 extern bool fBTGBootstrapping;
+extern bool fSkipHardforkIBD;
 
 //! -timeout default
 static const int DEFAULT_CONNECT_TIMEOUT = 5000;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1072,6 +1072,8 @@ bool IsInitialBlockDownload()
         return true;
     if (chainActive.Tip()->nChainWork < UintToArith256(chainParams.GetConsensus().nMinimumChainWork))
         return true;
+    if (fSkipHardforkIBD && chainActive.Tip()->nHeight + 1 >= (int)chainParams.GetConsensus().BTGHeight)
+        return false;
     int64_t target_time = fBTGBootstrapping ? (int64_t)chainParams.GetConsensus().BitcoinPostforkTime : GetTime();
     if (chainActive.Tip()->GetBlockTime() < (target_time - nMaxTipAge))
         return true;


### PR DESCRIPTION
When bootstrapping the Bitcoin Gold blockchain, the node is likely to be stuck at the last pre-fork height in the Initial Block Download status because its block time is a few days old. With flag `-skiphardforkibd` enabled, the client will exit IBD state when reaching the last pre-fork block to bypass this issue.