### PR TITLE
RPC: Add getblocksubsidy to rpc.

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -35,6 +35,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "generatetoaddress", 2, "maxtries" },
     { "getnetworkhashps", 0, "nblocks" },
     { "getnetworkhashps", 1, "height" },
+    { "getblocksubsidy", 0, "height" },
     { "sendtoaddress", 1, "amount" },
     { "sendtoaddress", 4, "subtractfeefromamount" },
     { "sendtoaddress", 5 , "replaceable" },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -840,7 +840,8 @@ UniValue getblocksubsidy(const JSONRPCRequest& request)
       "1. height          (numeric, optional) The block height. If not provided, defaults to the current height of the chain.\n"
       "\nResult:\n"
       "{\n"
-      "\"reward\" : n,    (numeric) The mining reward amount in satoshis.\n"
+      "\"miner\": n,    (numeric) The mining reward amount in satoshis.\n"
+      "\"founders\": f, (numeric) Always 0, for Zcash mining compatibility.\n"
       "}\n"
       "\nExamples:\n"
       + HelpExampleCli("getblocksubsidy", "1000")

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -852,12 +852,13 @@ UniValue getblocksubsidy(const JSONRPCRequest& request)
   LOCK(cs_main);
   int nHeight = (request.params.size() == 1) ? request.params[0].get_int() : chainActive.Height();
   if (nHeight < 0)
-    throw std::runtime_error("Block height out of range.");
+    throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range.");
 
   UniValue result(UniValue::VOBJ);
 
   CAmount nReward = GetBlockSubsidy(nHeight, Params().GetConsensus());
-  result.push_back(Pair("reward", nReward));
+  result.push_back(Pair("miner", nReward));
+  result.push_back(Pair("founders", 0));
 
   return result;
 }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -830,6 +830,38 @@ UniValue submitblock(const JSONRPCRequest& request)
     return BIP22ValidationResult(sc.state);
 }
 
+UniValue getblocksubsidy(const JSONRPCRequest& request)
+{
+  if (request.fHelp || request.params.size() > 1)
+    throw std::runtime_error(
+      "getblocksubsidy height\n"
+      "\nReturns block subsidy reward of block at index provided.\n"
+      "\nArguments:\n"
+      "1. height          (numeric, optional) The block height. If not provided, defaults to the current height of the chain.\n"
+      "\nResult:\n"
+      "{\n"
+      "\"reward\" : n,    (numeric) The mining reward amount in satoshis.\n"
+      "}\n"
+      "\nExamples:\n"
+      + HelpExampleCli("getblocksubsidy", "1000")
+      + HelpExampleRpc("getblocksubsidy", "1000")
+    );
+
+  RPCTypeCheck(request.params, {UniValue::VNUM});
+
+  LOCK(cs_main);
+  int nHeight = (request.params.size() == 1) ? request.params[0].get_int() : chainActive.Height();
+  if (nHeight < 0)
+    throw std::runtime_error("Block height out of range.");
+
+  UniValue result(UniValue::VOBJ);
+
+  CAmount nReward = GetBlockSubsidy(nHeight, Params().GetConsensus());
+  result.push_back(Pair("reward", nReward));
+
+  return result;
+}
+
 UniValue estimatefee(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
@@ -1036,6 +1068,7 @@ static const CRPCCommand commands[] =
     { "mining",             "prioritisetransaction",  &prioritisetransaction,  true,  {"txid","dummy","fee_delta"} },
     { "mining",             "getblocktemplate",       &getblocktemplate,       true,  {"template_request"} },
     { "mining",             "submitblock",            &submitblock,            true,  {"hexdata","dummy"} },
+    { "mining",             "getblocksubsidy",        &getblocksubsidy,        true,  {"height"} },
 
     { "generating",         "generatetoaddress",      &generatetoaddress,      true,  {"nblocks","address","maxtries"} },
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -351,16 +351,22 @@ BOOST_AUTO_TEST_CASE(rpc_getblocksubsidy)
     BOOST_CHECK_THROW(CallRPC(std::string("getblocksubsidy -1")), std::runtime_error);
     BOOST_CHECK_NO_THROW(result = CallRPC("getblocksubsidy 50000"));
     UniValue o1 = result.get_obj();
-    UniValue reward = find_value(o1, "reward");
-    BOOST_CHECK_EQUAL(reward.get_int64(), 5000000000);
+    UniValue miner = find_value(o1, "miner");
+    BOOST_CHECK_EQUAL(miner.get_int64(), 5000000000);
+    UniValue founders = find_value(o1, "founders");
+    BOOST_CHECK_EQUAL(founders.get_int64(), 0);
     BOOST_CHECK_NO_THROW(result = CallRPC("getblocksubsidy 1000000"));
     o1 = result.get_obj();
-    reward = find_value(o1, "reward");
-    BOOST_CHECK_EQUAL(reward.get_int64(), 312500000);
+    miner = find_value(o1, "miner");
+    BOOST_CHECK_EQUAL(miner.get_int64(), 312500000);
+    founders = find_value(o1, "founders");
+    BOOST_CHECK_EQUAL(founders.get_int64(), 0);
     BOOST_CHECK_NO_THROW(result = CallRPC("getblocksubsidy 2000000"));
     o1 = result.get_obj();
-    reward = find_value(o1, "reward");
-    BOOST_CHECK_EQUAL(reward.get_int64(), 9765625);
+    miner = find_value(o1, "miner");
+    BOOST_CHECK_EQUAL(miner.get_int64(), 9765625);
+    founders = find_value(o1, "founders");
+    BOOST_CHECK_EQUAL(founders.get_int64(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -343,4 +343,24 @@ BOOST_AUTO_TEST_CASE(rpc_convert_values_generatetoaddress)
     BOOST_CHECK_EQUAL(result[2].get_int(), 9);
 }
 
+BOOST_AUTO_TEST_CASE(rpc_getblocksubsidy)
+{
+    UniValue result;
+
+    BOOST_CHECK_THROW(CallRPC(std::string("getblocksubsidy too many args")), std::runtime_error);
+    BOOST_CHECK_THROW(CallRPC(std::string("getblocksubsidy -1")), std::runtime_error);
+    BOOST_CHECK_NO_THROW(result = CallRPC("getblocksubsidy 50000"));
+    UniValue o1 = result.get_obj();
+    UniValue reward = find_value(o1, "reward");
+    BOOST_CHECK_EQUAL(reward.get_int64(), 5000000000);
+    BOOST_CHECK_NO_THROW(result = CallRPC("getblocksubsidy 1000000"));
+    o1 = result.get_obj();
+    reward = find_value(o1, "reward");
+    BOOST_CHECK_EQUAL(reward.get_int64(), 312500000);
+    BOOST_CHECK_NO_THROW(result = CallRPC("getblocksubsidy 2000000"));
+    o1 = result.get_obj();
+    reward = find_value(o1, "reward");
+    BOOST_CHECK_EQUAL(reward.get_int64(), 9765625);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Mining pools expect the RPC interface to provide `getblocksubsidy` a simple deterministic function that calculates the block subsidy based on the chain height and the halving interval. See [validation.cpp](https://github.com/BTCGPU/BTCGPU/blob/master/src/validation.cpp#L1043) for implementation.

While workarounds exist to calculate this on the pool side, this change may reduce the difficulty of setting up a bgold pool, increasing adoption.

