### PR TITLE
Fix LWMA param k and denominator

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -116,7 +116,8 @@ public:
         consensus.nDigishieldMaxAdjustUp = 16;
 
         consensus.nZawyLwmaAveragingWindow = 45;
-        consensus.nZawyLwmaAjustedWeight = 13632;
+        consensus.nZawyLwmaAjustedWeight = 13772;
+        consensus.nZawyLwmaMinDenominator = 10;
         consensus.BTGMaxFutureBlockTime = 12 * 10 * 60; // 120 mins
         
         consensus.nPowTargetTimespanLegacy = 14 * 24 * 60 * 60; // 10 minutes
@@ -253,6 +254,7 @@ public:
 
         consensus.nZawyLwmaAveragingWindow = 45;
         consensus.nZawyLwmaAjustedWeight = 13632;
+        consensus.nZawyLwmaMinDenominator = 3;  // Legacy value. Use 10 in mainnet.
         consensus.BTGMaxFutureBlockTime = 7 * 10 * 60; // 70 mins
         
         consensus.nPowTargetTimespanLegacy = 14 * 24 * 60 * 60; // two weeks
@@ -361,7 +363,8 @@ public:
         consensus.nDigishieldMaxAdjustUp = 16;
 
         consensus.nZawyLwmaAveragingWindow = 45;
-        consensus.nZawyLwmaAjustedWeight = 13632;
+        consensus.nZawyLwmaAjustedWeight = 13772;
+        consensus.nZawyLwmaMinDenominator = 10;
         consensus.BTGMaxFutureBlockTime = 7 * 10 * 60; // 70 mins
 
         consensus.nPowTargetTimespanLegacy = 14 * 24 * 60 * 60; // two weeks

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -92,10 +92,10 @@ struct Params {
     }
 
     // Params for Zawy's LWMA difficulty adjustment algorithm. (Used by testnet and regtest)
-    int64_t nZawyLwmaAveragingWindow;  // N
-    int64_t nZawyLwmaAjustedWeight;  // k = (N+1)/2 * 0.9989^(500/N) * T
-
-    
+    int64_t nZawyLwmaAveragingWindow;  // N = 45
+    int64_t nZawyLwmaAjustedWeight;  // legacy equation (testnet): k = (N+1)/2 * 0.9989^(500/N) * T
+                                     // new equation (mainnet): k = (N+1)/2 * 0.998 *T
+    int64_t nZawyLwmaMinDenominator;
 };
 } // namespace Consensus
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -69,6 +69,7 @@ unsigned int LwmaCalculateNextWorkRequired(const CBlockIndex* pindexLast, const 
 
     const int N = params.nZawyLwmaAveragingWindow;
     const int k = params.nZawyLwmaAjustedWeight;
+    const int dnorm = params.nZawyLwmaMinDenominator;
     const int height = pindexLast->nHeight + 1;
     assert(height > N);
 
@@ -92,8 +93,8 @@ unsigned int LwmaCalculateNextWorkRequired(const CBlockIndex* pindexLast, const 
         sum_target += target / (k * N * N);
     }
     // Keep t reasonable in case strange solvetimes occurred.
-    if (t < N * k / 3) {
-        t = N * k / 3;
+    if (t < N * k / dnorm) {
+        t = N * k / dnorm;
     }
 
     const arith_uint256 pow_limit = UintToArith256(params.PowLimit(true));


### PR DESCRIPTION
As suggested by Zawy:
- Use `(N+1)/2 * 0.998 *T` instead of `(N+1)/2 * 0.9989^(500/N) * T`
  as k for mainnet
- Change the minimal weighted block time denominator from 3 to 10

Tested:
New testnet sync