### PR TITLE
Relex libsodium version requirement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -727,12 +727,12 @@ AC_CHECK_LIB(sodium, sodium_init,[],
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <sodium.h>
 ], [
-#if SODIUM_LIBRARY_VERSION_MAJOR < 9 || SODIUM_LIBRARY_VERSION_MAJOR == 9 && SODIUM_LIBRARY_VERSION_MINOR < 5
+#if SODIUM_LIBRARY_VERSION_MAJOR < 9 || SODIUM_LIBRARY_VERSION_MAJOR == 9 && SODIUM_LIBRARY_VERSION_MINOR < 1
 # error
 #endif
 ])],
 [AC_MSG_RESULT([checking for version of libsodium... yes])],
-[AC_MSG_ERROR([Wrong libsodium: version >= 1.0.13 required])])
+[AC_MSG_ERROR([Wrong libsodium: version >= 1.0.8 required])])
 
 BITCOIN_QT_INIT
 

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -108,8 +108,6 @@ int inline init_and_check_sodium()
         return -1;
     }
 
-    // What follows is a runtime test that ensures the version of libsodium
-    // we're linked against checks that signatures are canonical (s < L).
     const unsigned char message[1] = { 0 };
 
     unsigned char pk[crypto_sign_PUBLICKEYBYTES];
@@ -120,23 +118,6 @@ int inline init_and_check_sodium()
     crypto_sign_detached(sig, NULL, message, sizeof(message), sk);
 
     assert(crypto_sign_verify_detached(sig, message, sizeof(message), pk) == 0);
-
-    // Copied from libsodium/crypto_sign/ed25519/ref10/open.c
-    static const unsigned char L[32] = {
-        0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
-        0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10};
-
-    // Add L to S, which starts at sig[32].
-    unsigned int s = 0;
-    for (size_t i = 0; i < 32; i++) {
-        s = sig[32 + i] + L[i] + (s >> 8);
-        sig[32 + i] = s & 0xff;
-    }
-
-    assert(crypto_sign_verify_detached(sig, message, sizeof(message), pk) != 0);
-
     return 0;
 }
 


### PR DESCRIPTION
1.0.13 is no longer needed. 1.0.8 shipped with Ubuntu 16.04 is accepted now.