### PR TITLE
Replace libsodium with libb2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -719,20 +719,10 @@ if test x$use_upnp != xno; then
   )
 fi
 
-dnl Check to find the libsodium headers/libraries
-AC_CHECK_LIB(sodium, sodium_init,[],
-[AC_MSG_ERROR([The Sodium crypto library libraries not found.])]
+dnl Check to find the libb2 headers/libraries
+AC_CHECK_LIB(b2, blake2b_init_param, [],
+[AC_MSG_ERROR([The BLAKE2 crypto library not found.])]
 )
-
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
-#include <sodium.h>
-], [
-#if SODIUM_LIBRARY_VERSION_MAJOR < 9 || SODIUM_LIBRARY_VERSION_MAJOR == 9 && SODIUM_LIBRARY_VERSION_MINOR < 1
-# error
-#endif
-])],
-[AC_MSG_RESULT([checking for version of libsodium... yes])],
-[AC_MSG_ERROR([Wrong libsodium: version >= 1.0.8 required])])
 
 BITCOIN_QT_INIT
 
@@ -1045,7 +1035,7 @@ AC_SUBST(UNIVALUE_LIBS)
 
 BITCOIN_QT_PATH_PROGS([PROTOC], [protoc],$protoc_bin_path)
 
-LIBEQUIHASH_LIBS="-lcrypto -lsodium"
+LIBEQUIHASH_LIBS="-lcrypto -lb2"
 
 AC_MSG_CHECKING([whether to build bitcoind])
 AM_CONDITIONAL([BUILD_BITCOIND], [test x$build_bitcoind = xyes])

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -15,10 +15,6 @@ Copyright: 2010-2011, Jonas Smedegaard <dr@jones.dk>
            2011, Matt Corallo <matt@bluematt.me>
 License: GPL-2+
 
-Files: depends/sources/libsodium-*.tar.gz
-Copyright: 2013-2016 Frank Denis
-License: ISC
-
 Files: src/qt/res/icons/add.png
        src/qt/res/icons/address-book.png
        src/qt/res/icons/chevron.png

--- a/depends/packages/libb2.mk
+++ b/depends/packages/libb2.mk
@@ -9,10 +9,6 @@ $(package)_download_path=https://github.com/BLAKE2/libb2/releases/download/v$($(
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=e869e0c3a93bc56d1052eccbe9cd925b8a8c7308b417532829a700cf374b036f
 
-define $(package)_preprocess_cmds
-  ./autogen.sh
-endef
-
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/depends/packages/libb2.mk
+++ b/depends/packages/libb2.mk
@@ -8,6 +8,11 @@ $(package)_version=0.98
 $(package)_download_path=https://github.com/BLAKE2/libb2/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=e869e0c3a93bc56d1052eccbe9cd925b8a8c7308b417532829a700cf374b036f
+$(package)_patches=cross_compile.patch
+
+define $(package)_preprocess_cmds
+  patch ./configure < $($(package)_patch_dir)/cross_compile.patch
+endef
 
 define $(package)_config_cmds
   $($(package)_autoconf)

--- a/depends/packages/libb2.mk
+++ b/depends/packages/libb2.mk
@@ -3,21 +3,18 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-package=libsodium
-$(package)_version=1.0.15
-$(package)_download_path=https://download.libsodium.org/libsodium/releases
+package=libb2
+$(package)_version=0.98
+$(package)_download_path=https://github.com/BLAKE2/libb2/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=FB6A9E879A2F674592E4328C5D9F79F082405EE4BB05CB6E679B90AFE9E178F4
-$(package)_dependencies=
-$(package)_config_opts=
-$(package)_config_opts_linux=--with-pic
+$(package)_sha256_hash=e869e0c3a93bc56d1052eccbe9cd925b8a8c7308b417532829a700cf374b036f
 
 define $(package)_preprocess_cmds
-  cd $($(package)_build_subdir); ./autogen.sh
+  ./autogen.sh
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf) --enable-static --disable-shared
+  $($(package)_autoconf)
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-equihash_packages := libsodium
+equihash_packages := libb2
 packages:=boost openssl libevent zeromq $(equihash_packages)
 native_packages := native_ccache
 

--- a/depends/patches/libb2/cross_compile.patch
+++ b/depends/patches/libb2/cross_compile.patch
@@ -1,0 +1,12 @@
+13164,13166c13164,13170
+< 
+<       ecx=`echo $ax_cv_gcc_x86_cpuid_0x00000001 | cut -d ":" -f 3`
+<       edx=`echo $ax_cv_gcc_x86_cpuid_0x00000001 | cut -d ":" -f 4`
+---
+>       ecx=0
+>       edx=0
+>       if test "$ax_cv_gcc_x86_cpuid_0x00000001" != "unknown";
+>       then
+>          ecx=`echo $ax_cv_gcc_x86_cpuid_0x00000001 | cut -d ":" -f 3`
+>          edx=`echo $ax_cv_gcc_x86_cpuid_0x00000001 | cut -d ":" -f 4`
+>       fi

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ Then install [Homebrew](https://brew.sh).
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf qt libevent libsodium
+    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf qt libevent libb2
 
 If you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -65,7 +65,7 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libsodium-dev
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libb2-dev
 
 Options when installing required Boost library files:
 
@@ -103,23 +103,6 @@ Optional (see --with-miniupnpc and --enable-upnp-default):
 ZMQ dependencies (provides ZMQ API 4.x):
 
     sudo apt-get install libzmq3-dev
-
-3. On Ubuntu 16.04.3 you need to install the newest libsodium (at least 1.0.13)
-
-    configure: error: Wrong libsodium: version >= 1.0.13 required
-
-I tested it with version 1.0.15 (from the `depends` directory) at it works.
-
-    $ cd BTCGPU
-    $ cd depends
-    $ make
-    $ cd ..
-    $ ./autogen.sh
-    $ ./configure --prefix=`pwd`/depends/x86_64-pc-linux-gnu
-    $ make
-    $ make install
-
-The command `make install` installs the executables in the `./depends/x86_64-pc-linux-gnu/bin/` directory.
 
 Dependencies for the GUI: Ubuntu & Debian
 -----------------------------------------

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -13,7 +13,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "sodium.h"
 #include "compat/endian.h"
 
 uint16_t static inline ReadLE16(const unsigned char* ptr)
@@ -100,25 +99,6 @@ uint64_t static inline CountBits(uint64_t x)
         ++ret;
     }
     return ret;
-}
-
-int inline init_and_check_sodium()
-{
-    if (sodium_init() == -1) {
-        return -1;
-    }
-
-    const unsigned char message[1] = { 0 };
-
-    unsigned char pk[crypto_sign_PUBLICKEYBYTES];
-    unsigned char sk[crypto_sign_SECRETKEYBYTES];
-    unsigned char sig[crypto_sign_BYTES];
-
-    crypto_sign_keypair(pk, sk);
-    crypto_sign_detached(sig, NULL, message, sizeof(message), sk);
-
-    assert(crypto_sign_verify_detached(sig, message, sizeof(message), pk) == 0);
-    return 0;
 }
 
 #endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -39,7 +39,7 @@ int Equihash<N,K>::InitialiseState(eh_HashState& base_state, bool btg_salt)
 {
     uint32_t le_N = htole32(N);
     uint32_t le_K = htole32(K);
-    unsigned char personalization[crypto_generichash_blake2b_PERSONALBYTES] = {};
+    unsigned char personalization[BLAKE2B_PERSONALBYTES] = {};
     if (btg_salt) {
         memcpy(personalization, "BgoldPoW", 8);
     } else {
@@ -47,11 +47,21 @@ int Equihash<N,K>::InitialiseState(eh_HashState& base_state, bool btg_salt)
     }
     memcpy(personalization+8,  &le_N, 4);
     memcpy(personalization+12, &le_K, 4);
-    return crypto_generichash_blake2b_init_salt_personal(&base_state,
-                                                         NULL, 0, // No key.
-                                                         (512/N)*N/8,
-                                                         NULL,    // No salt.
-                                                         personalization);
+
+    blake2b_param param[1];
+    param->digest_length = (512/N)*N/8;
+    param->key_length    = 0;
+    param->fanout        = 1;
+    param->depth         = 1;
+    store32(&param->leaf_length, 0);
+    store64(&param->node_offset, 0);
+    param->node_depth    = 0;
+    param->inner_length  = 0;
+    memset(param->reserved, 0, sizeof(param->reserved));
+    memset(param->salt, 0, sizeof(param->salt));
+    memcpy(param->personal, personalization, BLAKE2B_PERSONALBYTES);
+
+    return blake2b_init_param(&base_state, param);
 }
 
 void GenerateHash(const eh_HashState& base_state, eh_index g,
@@ -60,9 +70,8 @@ void GenerateHash(const eh_HashState& base_state, eh_index g,
     eh_HashState state;
     state = base_state;
     eh_index lei = htole32(g);
-    crypto_generichash_blake2b_update(&state, (const unsigned char*) &lei,
-                                      sizeof(eh_index));
-    crypto_generichash_blake2b_final(&state, hash, hLen);
+    blake2b_update(&state, (const unsigned char*) &lei, sizeof(eh_index));
+    blake2b_final(&state, hash, hLen);
 }
 
 void ExpandArray(const unsigned char* in, size_t in_len,

--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -12,7 +12,7 @@
 #include "crypto/sha256.h"
 #include "utilstrencodings.h"
 
-#include "sodium.h"
+#include "blake2.h"
 
 #include <cstring>
 #include <exception>
@@ -23,7 +23,7 @@
 
 #include <boost/static_assert.hpp>
 
-typedef crypto_generichash_blake2b_state eh_HashState;
+typedef blake2b_state eh_HashState;
 typedef uint32_t eh_index;
 typedef uint8_t eh_trunc;
 
@@ -301,6 +301,36 @@ inline unsigned int EhSolutionWidth(int n, int k)
         throw std::invalid_argument("Unsupported Equihash parameters");
     }
     return ret;
+}
+
+static inline void store32(void *dst, uint32_t w)
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+    memcpy(dst, &w, sizeof(w));
+#else
+    uint8_t *p = (uint8_t *)dst;
+    *p++ = (uint8_t)w; w >>= 8;
+    *p++ = (uint8_t)w; w >>= 8;
+    *p++ = (uint8_t)w; w >>= 8;
+    *p++ = (uint8_t)w;
+#endif
+}
+
+static inline void store64(void *dst, uint64_t w)
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+    memcpy(dst, &w, sizeof(w));
+#else
+    uint8_t *p = (uint8_t *)dst;
+    *p++ = (uint8_t)w; w >>= 8;
+    *p++ = (uint8_t)w; w >>= 8;
+    *p++ = (uint8_t)w; w >>= 8;
+    *p++ = (uint8_t)w; w >>= 8;
+    *p++ = (uint8_t)w; w >>= 8;
+    *p++ = (uint8_t)w; w >>= 8;
+    *p++ = (uint8_t)w; w >>= 8;
+    *p++ = (uint8_t)w;
+#endif
 }
 
 #endif // BITCOIN_EQUIHASH_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1162,11 +1162,6 @@ bool AppInitSanityChecks()
 {
     // ********************************************************* Step 4: sanity checks
 
-    // Initialize libsodium
-    if (init_and_check_sodium() == -1) {
-        return false;
-    }
-
     // Initialize elliptic curve code
     std::string sha256_algo = SHA256AutoDetect();
     LogPrintf("Using the '%s' SHA256 implementation\n", sha256_algo);

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -250,7 +250,7 @@ bool CheckEquihashSolution(const CBlockHeader *pblock, const CChainParams& param
     unsigned int k = params.EquihashK(height);
 
     // Hash state
-    crypto_generichash_blake2b_state state;
+    blake2b_state state;
     EhInitialiseState(n, k, state, params.EquihashUseBTGSalt(height));
 
     // I = the block header minus nonce and solution.
@@ -261,7 +261,7 @@ bool CheckEquihashSolution(const CBlockHeader *pblock, const CChainParams& param
     ss << pblock->nNonce;
 
     // H(I||V||...
-    crypto_generichash_blake2b_update(&state, (unsigned char*)&ss[0], ss.size());
+    blake2b_update(&state, (unsigned char*)&ss[0], ss.size());
 
     bool isValid;
     EhIsValidSolution(n, k, state, pblock->nSolution, isValid);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -157,7 +157,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             nInnerLoopCount = nInnerLoopEquihashCount;
             n = params.EquihashN(pblock->nHeight);
             k = params.EquihashK(pblock->nHeight);
-            crypto_generichash_blake2b_state eh_state;
+            blake2b_state eh_state;
             EhInitialiseState(n, k, eh_state, params.EquihashUseBTGSalt(pblock->nHeight));
 
             // I = the block header minus nonce and solution.
@@ -166,7 +166,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             ss << I;
 
             // H(I||...
-            crypto_generichash_blake2b_update(&eh_state, (unsigned char*)&ss[0], ss.size());
+            blake2b_update(&eh_state, (unsigned char*)&ss[0], ss.size());
 
             while (nMaxTries > 0 &&
                    ((int)pblock->nNonce.GetUint64(0) & nInnerLoopEquihashMask) < nInnerLoopCount) {
@@ -175,11 +175,9 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
                 pblock->nNonce = ArithToUint256(UintToArith256(pblock->nNonce) + 1);
 
                 // H(I||V||...
-                crypto_generichash_blake2b_state curr_state;
+                blake2b_state curr_state;
                 curr_state = eh_state;
-                crypto_generichash_blake2b_update(&curr_state,
-                                                  pblock->nNonce.begin(),
-                                                  pblock->nNonce.size());
+                blake2b_update(&curr_state, pblock->nNonce.begin(), pblock->nNonce.size());
 
                 // (x_1, x_2, ...) = A(I, V, n, k)
                 std::function<bool(std::vector<unsigned char>)> validBlock =

--- a/src/test/equihash_tests.cpp
+++ b/src/test/equihash_tests.cpp
@@ -14,7 +14,7 @@
 #include "uint256.h"
 #include "utilstrencodings.h"
 
-#include "sodium.h"
+#include "blake2.h"
 
 #include <sstream>
 #include <set>
@@ -47,12 +47,12 @@ void PrintSolutions(std::stringstream &strm, std::set<std::vector<uint32_t>> sol
 
 void TestEquihashSolvers(unsigned int n, unsigned int k, const std::string &I, const arith_uint256 &nonce, const std::set<std::vector<uint32_t>> &solns) {
     size_t cBitLen { n/(k+1) };
-    crypto_generichash_blake2b_state state;
+    blake2b_state state;
     EhInitialiseState(n, k, state, false);
     uint256 V = ArithToUint256(nonce);
     BOOST_TEST_MESSAGE("Running solver: n = " << n << ", k = " << k << ", I = " << I << ", V = " << V.GetHex());
-    crypto_generichash_blake2b_update(&state, (unsigned char*)&I[0], I.size());
-    crypto_generichash_blake2b_update(&state, V.begin(), V.size());
+    blake2b_update(&state, (unsigned char*)&I[0], I.size());
+    blake2b_update(&state, V.begin(), V.size());
 
     // First test the basic solver
     std::set<std::vector<uint32_t>> ret;
@@ -86,11 +86,11 @@ void TestEquihashSolvers(unsigned int n, unsigned int k, const std::string &I, c
 
 void TestEquihashValidator(unsigned int n, unsigned int k, const std::string &I, const arith_uint256 &nonce, std::vector<uint32_t> soln, bool expected) {
     size_t cBitLen { n/(k+1) };
-    crypto_generichash_blake2b_state state;
+    blake2b_state state;
     EhInitialiseState(n, k, state, false);
     uint256 V = ArithToUint256(nonce);
-    crypto_generichash_blake2b_update(&state, (unsigned char*)&I[0], I.size());
-    crypto_generichash_blake2b_update(&state, V.begin(), V.size());
+    blake2b_update(&state, (unsigned char*)&I[0], I.size());
+    blake2b_update(&state, V.begin(), V.size());
     BOOST_TEST_MESSAGE("Running validator: n = " << n << ", k = " << k << ", I = " << I << ", V = " << V.GetHex() << ", expected = " << expected << ", soln =");
     std::stringstream strm;
     PrintSolution(strm, soln);
@@ -201,9 +201,9 @@ BOOST_AUTO_TEST_CASE(validator_144_5_btg_salt) {
     unsigned int k = 5;
     std::vector<unsigned char> IV = ParseHex("0400000008e9694cc2120ec1b5733cc12687b609058eec4f7046a521ad1d1e3049b400003e7420ed6f40659de0305ef9b7ec037f4380ed9848bc1c015691c90aa16ff3930000000000000000000000000000000000000000000000000000000000000000c9310d5874e0001f000000000000000000000000000000010b000000000000000000000000666666");
     std::vector<unsigned char> soln = ParseHex("01629b3779fd498defb2b0a551f7e111a8a003711acfe129622eb80bc98df66b9d8178b9670bacdc972b250fcb6715f437eb0addf858f9419c03f93a1be742e6377d4dcc4b9196afd811592ee4589cecfa321e7a9d5675338e7834923fe12b49f743a8d4");
-    crypto_generichash_blake2b_state state;
+    blake2b_state state;
     EhInitialiseState(n, k, state, true);
-    crypto_generichash_blake2b_update(&state, (unsigned char*)&IV[0], IV.size());
+    blake2b_update(&state, (unsigned char*)&IV[0], IV.size());
     bool is_valid;
     EhIsValidSolution(n, k, state, soln, is_valid);
     BOOST_CHECK(is_valid);

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -15,7 +15,6 @@ BOOST_AUTO_TEST_CASE(basic_sanity)
   BOOST_CHECK_MESSAGE(glibc_sanity_test() == true, "libc sanity test");
   BOOST_CHECK_MESSAGE(glibcxx_sanity_test() == true, "stdlib sanity test");
   BOOST_CHECK_MESSAGE(ECC_InitSanityCheck() == true, "openssl ECC test");
-  BOOST_CHECK_MESSAGE(init_and_check_sodium() == 0, "libsodium sanity test");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Exactly what the title says - removed anything related to libsodium and replaced it with libb2.

All tests pass. Tested via:
`make check`
`./test/functional/test_runner.py`

Cross compile build also tested.