### PR TITLE
Fix win32/win64 Travis build

### DIFF
--- a/depends/patches/libb2/cross_compile.patch
+++ b/depends/patches/libb2/cross_compile.patch
@@ -1,10 +1,11 @@
-13164,13166c13164,13170
+13164,13166c13164,13171
 < 
 <       ecx=`echo $ax_cv_gcc_x86_cpuid_0x00000001 | cut -d ":" -f 3`
 <       edx=`echo $ax_cv_gcc_x86_cpuid_0x00000001 | cut -d ":" -f 4`
 ---
 >       ecx=0
 >       edx=0
+>       ax_cv_gcc_x86_cpuid_0x00000001=${ax_cv_gcc_x86_cpuid_0x00000001//[ $'\r' ]}
 >       if test "$ax_cv_gcc_x86_cpuid_0x00000001" != "unknown";
 >       then
 >          ecx=`echo $ax_cv_gcc_x86_cpuid_0x00000001 | cut -d ":" -f 3`


### PR DESCRIPTION
Contains a patch that would fix the Travis build for Win32/64.