### PR TITLE
Fix NetworkHashPS defualt lookup window

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -59,7 +59,7 @@ static UniValue GetNetworkHashPS(int lookup, int height) {
 
     // If lookup is -1, then use blocks since last difficulty change.
     if (lookup <= 0)
-        lookup = pb->nHeight % Params().GetConsensus().DifficultyAdjustmentInterval() + 1;
+        lookup = Params().GetConsensus().nZawyLwmaAveragingWindow;
 
     // If lookup is larger than chain, then set it to chain length.
     if (lookup > pb->nHeight)


### PR DESCRIPTION
The old behavior is to estimate the network hash rate from the last diff adjustment block when `lookup == -1`. After switching to LWMA, difficulty changes every block. So instead, we use the LWMA window as the default lookup window.