### PR TITLE
Better arg name: maxexpectedreorgdepth

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -374,7 +374,7 @@ void SetupServerArgs()
     gArgs.AddArg("-maxmempool=<n>", strprintf("Keep the transaction memory pool below <n> megabytes (default: %u)", DEFAULT_MAX_MEMPOOL_SIZE), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxorphantx=<n>", strprintf("Keep at most <n> unconnectable transactions in memory (default: %u)", DEFAULT_MAX_ORPHAN_TRANSACTIONS), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-mempoolexpiry=<n>", strprintf("Do not keep transactions in the mempool longer than <n> hours (default: %u)", DEFAULT_MEMPOOL_EXPIRY), false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-maxreorgdepth=<n>", strprintf("Configure at what depth blocks are considered final (default: %d). Use -1 to disable.", DEFAULT_MAX_REORG_DEPTH), false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-maxexpectedreorgdepth=<n>", strprintf("Configure at what expected depth blocks are considered final (default: %d). Use -1 to disable.", DEFAULT_MAX_EXPECTED_REORG_DEPTH), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex()), true, OptionsCategory::OPTIONS);
     gArgs.AddArg("-par=<n>", strprintf("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)",
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), false, OptionsCategory::OPTIONS);

--- a/src/test/finalization_tests.cpp
+++ b/src/test/finalization_tests.cpp
@@ -27,10 +27,10 @@ BOOST_AUTO_TEST_CASE(finalizationDelay) {
                                 << chainActive.Tip()->nHeight << ")");
     }
 
-    // Create maxreorgdepth blocks. Auto-finalization will not occur because
+    // Create maxexpectedreorgdepth / 2 blocks. Auto-finalization will not occur because
     // the delay is not expired
     int64_t mockedTime = GetTime();
-    for (uint32_t i = 0; i < DEFAULT_MAX_REORG_DEPTH; i++) {
+    for (uint32_t i = 0; i < DEFAULT_MAX_EXPECTED_REORG_DEPTH / 2; i++) {
         block = CreateAndProcessBlock({}, p2pk_scriptPubKey);
         LOCK(cs_main);
         // These blocks are too recent.
@@ -43,11 +43,11 @@ BOOST_AUTO_TEST_CASE(finalizationDelay) {
     mockedTime += DEFAULT_MIN_FINALIZATION_DELAY + 1;
     SetMockTime(mockedTime);
 
-    // Next maxreorgdepth blocks should cause auto-finalization
+    // Next maxexpectedreorgdepth / 2 blocks should cause auto-finalization
     CBlockIndex *blockToFinalize = chainActive.Tip()->GetAncestor(
-        chainActive.Tip()->nHeight - DEFAULT_MAX_REORG_DEPTH);
+        chainActive.Tip()->nHeight - DEFAULT_MAX_EXPECTED_REORG_DEPTH / 2);
 
-    for (uint32_t i = 0; i < DEFAULT_MAX_REORG_DEPTH; i++) {
+    for (uint32_t i = 0; i < DEFAULT_MAX_EXPECTED_REORG_DEPTH / 2; i++) {
         blockToFinalize = chainActive.Next(blockToFinalize);
         block = CreateAndProcessBlock({}, p2pk_scriptPubKey);
         LOCK(cs_main);
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(finalizationDelay) {
 
     // Next blocks won't cause auto-finalization because the delay is not
     // expired
-    for (uint32_t i = 0; i < DEFAULT_MAX_REORG_DEPTH; i++) {
+    for (uint32_t i = 0; i < DEFAULT_MAX_EXPECTED_REORG_DEPTH / 2; i++) {
         block = CreateAndProcessBlock({}, p2pk_scriptPubKey);
         LOCK(cs_main);
         // These blocks are finalized.
@@ -76,11 +76,11 @@ BOOST_AUTO_TEST_CASE(finalizationDelay) {
     SetMockTime(mockedTime);
 
     blockToFinalize = chainActive.Tip()->GetAncestor(
-        chainActive.Tip()->nHeight - DEFAULT_MAX_REORG_DEPTH);
+        chainActive.Tip()->nHeight - DEFAULT_MAX_EXPECTED_REORG_DEPTH / 2);
 
     // Create some more blocks.
     // Finalization should start moving again.
-    for (uint32_t i = 0; i < DEFAULT_MAX_REORG_DEPTH; i++) {
+    for (uint32_t i = 0; i < DEFAULT_MAX_EXPECTED_REORG_DEPTH / 2; i++) {
         blockToFinalize = chainActive.Next(blockToFinalize);
         block = CreateAndProcessBlock({}, p2pk_scriptPubKey);
         LOCK(cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2505,8 +2505,10 @@ static const CBlockIndex *FindBlockToFinalize(CBlockIndex *pindexNew)
 {
     AssertLockHeld(cs_main);
 
-    const int32_t maxreorgdepth =
-        gArgs.GetArg("-maxreorgdepth", DEFAULT_MAX_REORG_DEPTH);
+    const int32_t maxexpectedreorgdepth =
+        gArgs.GetArg("-maxexpectedreorgdepth", DEFAULT_MAX_EXPECTED_REORG_DEPTH);
+    const int32_t maxreorgdepth = maxexpectedreorgdepth < 0 ?
+        maxexpectedreorgdepth : maxexpectedreorgdepth / 2;
 
     const int64_t finalizationdelay =
         gArgs.GetArg("-finalizationdelay", DEFAULT_MIN_FINALIZATION_DELAY);
@@ -2531,7 +2533,7 @@ static const CBlockIndex *FindBlockToFinalize(CBlockIndex *pindexNew)
     while (pindex && (pindex != pindexFinalized)) {
         // Check that the block to finalize is known for a long enough time.
         // This test will ensure that an attacker could not cause a block to
-        // finalize by forking the chain with a depth > maxreorgdepth.
+        // finalize by forking the chain with a depth > maxexpectedreorgdepth.
         // If the block is loaded from disk, header receive time is 0 and the
         // block will be finalized. This is safe because the delay since the
         // node startup is already expired.

--- a/src/validation.h
+++ b/src/validation.h
@@ -135,15 +135,15 @@ static const bool DEFAULT_PEERBLOOMFILTERS = true;
 
 /** Default for -stopatheight */
 static const int DEFAULT_STOPATHEIGHT = 0;
-/** Default for -maxreorgdepth */
-static const int DEFAULT_MAX_REORG_DEPTH = 47;
+/** Default for -maxexpectedreorgdepth */
+static const int DEFAULT_MAX_EXPECTED_REORG_DEPTH = 20;
 /**
  * Default for -finalizationdelay
  * This is the minimum time between a block header reception and the block
  * finalization.
  * This value should be >> block propagation and validation time
  */
-static const int64_t DEFAULT_MIN_FINALIZATION_DELAY = 2 * 60 * 60;
+static const int64_t DEFAULT_MIN_FINALIZATION_DELAY = 80 * 60;
 
 struct BlockHasher
 {

--- a/test/functional/feature_btg_finalize_block.py
+++ b/test/functional/feature_btg_finalize_block.py
@@ -37,11 +37,11 @@ def print_blocks_to_finalized(logger, node):
 class FinalizeBlockTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
-        self.extra_args = [["-maxreorgdepth=10", "-finalizationdelay=0", "-whitelist=127.0.0.1"],
-                           ["-maxreorgdepth=10", "-finalizationdelay=0"],
-                           ["-maxreorgdepth=10"],
-                           ["-maxreorgdepth=10"]]
-        self.finalization_delay = 2 * 60 * 60
+        self.extra_args = [["-maxexpectedreorgdepth=20", "-finalizationdelay=0", "-whitelist=127.0.0.1"],
+                           ["-maxexpectedreorgdepth=20", "-finalizationdelay=0"],
+                           ["-maxexpectedreorgdepth=20"],
+                           ["-maxexpectedreorgdepth=20"]]
+        self.finalization_delay = 80 * 60
 
     def run_test(self):
         node = self.nodes[0]


### PR DESCRIPTION
`-maxreorgdepth` doesn't mean the block at that depth always gets finalized. Considering the block finliazation delay and the standard variance of the block producing time, we introduce a new argument `-maxexpectedreorgdepth`, which is 2 times the max reorg depth, to be a better reference of setting block confirmation number.

This PR also reduce the `-finalizationdelay` to 4800 seconds and reduce `-maxexpectedreorgdepth` to 20.