### PR TITLE
Fix build errors under Nix

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -14,6 +14,7 @@
 #include <ui_interface.h>
 
 #include <memory>
+#include <deque>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -15,6 +15,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <cuckoocache.h>
+#include <functional>
 #include <hash.h>
 #include <index/txindex.h>
 #include <policy/fees.h>
@@ -53,6 +54,8 @@
 
 #define MICRO 0.000001
 #define MILLI 0.001
+
+using namespace std::placeholders;
 
 /**
  * Global state

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -15,8 +15,11 @@
 #include <list>
 #include <atomic>
 #include <future>
+#include <functional>
 
 #include <boost/signals2/signal.hpp>
+
+using namespace std::placeholders;
 
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;


### PR DESCRIPTION
```
  CXX      libbitcoin_common_a-coins.o
validationinterface.cpp:63:91: error: use of undeclared identifier '_1'
    pool.NotifyEntryRemoved.connect(boost::bind(&CMainSignals::MempoolEntryRemoved, this, _1, _2));
                                                                                          ^
validationinterface.cpp:63:95: error: use of undeclared identifier '_2'
    pool.NotifyEntryRemoved.connect(boost::bind(&CMainSignals::MempoolEntryRemoved, this, _1, _2));
```

(etc)